### PR TITLE
Make compatiable with Odoo 14

### DIFF
--- a/lib/OpenERP/OOM/Class/Base.pm
+++ b/lib/OpenERP/OOM/Class/Base.pm
@@ -11,9 +11,6 @@ use Try::Tiny;
 use Try::Tiny::Retry;
 use Time::HiRes qw/usleep/;
 
-use Pulsar::Debug qw<log_enter_exit>;
-use Data::Dump qw<pp>;
-
 extends 'Moose::Object';
 with 'OpenERP::OOM::DynamicUtils';
 
@@ -123,9 +120,7 @@ to return stock levels as well as the location details for example.
 =cut
 
 sub raw_search {
-    my $LEAVE = log_enter_exit('Class::Base::raw_search');
     my $self = shift;
-    say STDERR '\@_: ' . pp(\@_);
     return $self->_raw_search(0, @_);
 }
 
@@ -166,11 +161,8 @@ sub _search_limited_fields {
 }
 
 sub _raw_search {
-    my $LEAVE = log_enter_exit('Class::Base::raw_search');
     my ($self, $ids_only, @args) = @_;
     ### Initial search args: @args
-    say STDERR '$ids_only: ' . pp($ids_only);
-    say STDERR '\@args: ' . pp(\@args);
     my @search;
     while (@args && ref $args[0] ne 'HASH') {push @search, shift @args}
     
@@ -199,7 +191,6 @@ sub _raw_search {
             }
         }
     }
-    say STDERR '\@search: ' . pp(\@search);
     my $context = $self->_get_context(shift @args);
     my $options = shift @args;
     $options = {} unless $options;
@@ -212,8 +203,6 @@ sub _raw_search {
     }
 
     my $objects = $self->schema->client->search_detail($self->object_class->model,[@search], $context, $options->{offset}, $options->{limit}, $options->{order});
-    use Data::Dump qw<pp>;
-    say STDERR 'XXX $objects = ' . pp($objects);
 
     if ($objects) {    
         foreach my $attribute ($self->object_class->meta->get_all_attributes) {
@@ -230,11 +219,8 @@ sub _raw_search {
 
 sub search
 {
-    my $LEAVE = log_enter_exit('Class::Base::search');
     my $self = shift;
-    say STDERR '\@_: ' . pp(\@_);
     my $objects = $self->raw_search(@_);
-    say STDERR '$objects: ' . pp($objects);
     if($objects) {
         return map {$self->object_class->new($_)} @$objects;
     } else {

--- a/lib/OpenERP/OOM/Class/Base.pm
+++ b/lib/OpenERP/OOM/Class/Base.pm
@@ -503,8 +503,10 @@ sub _collapse_data_to_ids
         if ($rel->{type} eq 'many2one') {
             if ($object_data->{$name}) {
                 $object_data->{$rel->{key}} = $self->_id($rel, $object_data->{$name});
-                delete $object_data->{$name} if $name ne $rel->{key};
-            }            
+            }
+            if ($name ne $rel->{key}) {
+                delete $object_data->{$name};
+            }
         }
         if ($rel->{type} eq 'many2many') {
             if ($object_data->{$name}) {

--- a/lib/OpenERP/OOM/Class/Base.pm
+++ b/lib/OpenERP/OOM/Class/Base.pm
@@ -11,6 +11,9 @@ use Try::Tiny;
 use Try::Tiny::Retry;
 use Time::HiRes qw/usleep/;
 
+use Pulsar::Debug qw<log_enter_exit>;
+use Data::Dump qw<pp>;
+
 extends 'Moose::Object';
 with 'OpenERP::OOM::DynamicUtils';
 
@@ -120,7 +123,9 @@ to return stock levels as well as the location details for example.
 =cut
 
 sub raw_search {
+    my $LEAVE = log_enter_exit('Class::Base::raw_search');
     my $self = shift;
+    say STDERR '\@_: ' . pp(\@_);
     return $self->_raw_search(0, @_);
 }
 
@@ -161,9 +166,11 @@ sub _search_limited_fields {
 }
 
 sub _raw_search {
+    my $LEAVE = log_enter_exit('Class::Base::raw_search');
     my ($self, $ids_only, @args) = @_;
     ### Initial search args: @args
-    
+    say STDERR '$ids_only: ' . pp($ids_only);
+    say STDERR '\@args: ' . pp(\@args);
     my @search;
     while (@args && ref $args[0] ne 'HASH') {push @search, shift @args}
     
@@ -192,7 +199,7 @@ sub _raw_search {
             }
         }
     }
-    
+    say STDERR '\@search: ' . pp(\@search);
     my $context = $self->_get_context(shift @args);
     my $options = shift @args;
     $options = {} unless $options;
@@ -205,6 +212,8 @@ sub _raw_search {
     }
 
     my $objects = $self->schema->client->search_detail($self->object_class->model,[@search], $context, $options->{offset}, $options->{limit}, $options->{order});
+    use Data::Dump qw<pp>;
+    say STDERR 'XXX $objects = ' . pp($objects);
 
     if ($objects) {    
         foreach my $attribute ($self->object_class->meta->get_all_attributes) {
@@ -221,8 +230,11 @@ sub _raw_search {
 
 sub search
 {
+    my $LEAVE = log_enter_exit('Class::Base::search');
     my $self = shift;
+    say STDERR '\@_: ' . pp(\@_);
     my $objects = $self->raw_search(@_);
+    say STDERR '$objects: ' . pp($objects);
     if($objects) {
         return map {$self->object_class->new($_)} @$objects;
     } else {

--- a/lib/OpenERP/OOM/DynamicUtils.pm
+++ b/lib/OpenERP/OOM/DynamicUtils.pm
@@ -45,7 +45,9 @@ This library is free software; you can redistribute it and/or modify it under th
 
 use Class::Inspector;
 use Moose::Role;
+
 use Carp ();
+use RPC::XML qw<RPC_BOOLEAN>;
 
 my $invalid_class = qr/(?: \b:\b | \:{3,} | \:\:$ )/x;
 
@@ -78,11 +80,15 @@ sub prepare_attribute_for_send
     my $type = shift;
     my $value = shift;
 
-    return RPC::XML::string->new($value) if $type =~ /Str/i && defined $value;
-    return RPC::XML::boolean->new($value) if $type =~ /Str/i; # return null in effect
-    return $value->ymd if $type =~ qr'DateTime'i && $value && ref $value && $value->can('ymd');
-    
-    return $value;
+    if (!defined $value)
+        { return RPC_BOOLEAN(0); }
+    elsif ($type =~ /Str/i)
+        { return RPC::XML::string->new($value); }
+    elsif ($type =~ qr'DateTime'i && $value && ref $value && $value->can('ymd'))
+        { return $value->ymd; }
+        # ^ TODO that only the date part matters is a terrible assumption to make
+    else
+        { return $value; }
 }
 
 1;

--- a/lib/OpenERP/OOM/Object/Base.pm
+++ b/lib/OpenERP/OOM/Object/Base.pm
@@ -10,6 +10,8 @@ use Try::Tiny::Retry;
 use Time::HiRes qw/usleep/;
 use Switch::Plain;
 
+use Data::Dump qw<pp>;
+
 extends 'Moose::Object';
 with 'OpenERP::OOM::DynamicUtils';
 

--- a/lib/OpenERP/OOM/Object/Base.pm
+++ b/lib/OpenERP/OOM/Object/Base.pm
@@ -158,9 +158,20 @@ sub update {
             $object->{$attribute->name} = $self->prepare_attribute_for_send($attribute->type_constraint, $object->{$attribute->name});
         }
     }
+    say STDERR 'XXXXXX $object after prepare_attribute_for_send : ' . pp($object);
 
     $self->class->_with_retries(sub {
-        $self->class->schema->client->update($self->model, $self->id, $object, $context);
+        $self->class->schema->client->object_execute_kw(
+            'write',
+            $self->model,
+            [ # positional args
+                $self->id,
+                $object,
+            ],
+            { # keyword args
+                context => $context,
+            },
+        );
     });
     $self->refresh;
 

--- a/lib/OpenERP/OOM/Object/Base.pm
+++ b/lib/OpenERP/OOM/Object/Base.pm
@@ -10,8 +10,6 @@ use Try::Tiny::Retry;
 use Time::HiRes qw/usleep/;
 use Switch::Plain;
 
-use Data::Dump qw<pp>;
-
 extends 'Moose::Object';
 with 'OpenERP::OOM::DynamicUtils';
 
@@ -160,7 +158,6 @@ sub update {
             $object->{$attribute->name} = $self->prepare_attribute_for_send($attribute->type_constraint, $object->{$attribute->name});
         }
     }
-    say STDERR 'XXXXXX $object after prepare_attribute_for_send : ' . pp($object);
 
     $self->class->_with_retries(sub {
         $self->class->schema->client->object_execute_kw(


### PR DESCRIPTION
This changes some things to make them compatible with Odoo 14:
* Pass context to write() as a keyword argument instead of positional
* Pass 'undef' to Odoo as XML-RPC false - Odoo has become more fussy about this and won't accept an XML-RPC nil any more.

I've mounted this into my other BCA environment and run all the automated tests to check it still works with Odoo 8 and it all looks OK.

See the individual commit messages for a list of what was necessary.

I've also changed a couple of things from postfix if and early return to a more structured if..elsif..else structure, in which it's easier to see the branching logic.  Please read the code carefully where I've done this to convince yourself the new code is semantically the same.